### PR TITLE
Upgrade "temp" module to 0.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lodash.merge": "3.3.2",
     "request": "^2.81.0",
     "streamifier": "0.1.0",
-    "temp": "0.8.1",
+    "temp": "0.9.4",
     "uuid": "2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The older version of "temp" does not work under Node 14, with "TypeError: os.tmpDir is not a function". `os.tmpDir` has long been deprecated in favor of `os.tmpdir`, which has been available since at least Node 0.10.x, and Node 14 has finally removed the deprecated function.